### PR TITLE
Replace onclick attribute with EventListener

### DIFF
--- a/dark-mode-for-astra.php
+++ b/dark-mode-for-astra.php
@@ -10,7 +10,7 @@
  * Plugin Name: Dark Mode for Astra
  * Plugin URI: https://github.com/2ndkauboy/dark-mode-for-astra
  * Description: A plugin to add a dark mode toggle to the frontend using one of the color schemes defined in the customizer.
- * Version: 1.0.0-alpha-4
+ * Version: 1.0.0-alpha-5
  * Author: Bernhard Kau
  * Author URI: https://kau-boys.de
  * Text Domain: dark-mode-for-astra
@@ -19,7 +19,7 @@
  * GitHub Plugin URI: https://github.com/2ndkauboy/dark-mode-for-astra
  */
 
-define( 'DMFA_VERSION', '1.0.0-alpha-4' );
+define( 'DMFA_VERSION', '1.0.0-alpha-5' );
 define( 'DMFA_FILE', __FILE__ );
 define( 'DMFA_PATH', plugin_dir_path( DMFA_FILE ) );
 define( 'DMFA_URL', plugin_dir_url( DMFA_FILE ) );

--- a/lib/Helpers/DarkMode.php
+++ b/lib/Helpers/DarkMode.php
@@ -35,7 +35,6 @@ class DarkMode {
 				'id'           => 'dark-mode-toggler',
 				'class'        => '',
 				'aria-pressed' => 'false',
-				'onClick'      => 'astraToggleDarkMode()',
 			],
 			$attrs
 		);

--- a/src/dark-mode-toggler.js
+++ b/src/dark-mode-toggler.js
@@ -42,9 +42,11 @@ function darkModeInitialLoad() {
 		toggler.setAttribute( 'aria-pressed', 'true' );
 	}
 
-	if ( 'fixed' === window.getComputedStyle( document.getElementById( 'dark-mode-toggler' ) ).position ) {
+	if ( 'fixed' === window.getComputedStyle( toggler ).position ) {
 		darkModeRepositionTogglerOnScroll();
 	}
+
+	toggler.addEventListener( 'click', astraToggleDarkMode );
 }
 
 function darkModeRepositionTogglerOnScroll() {


### PR DESCRIPTION
Astra is adding an EventListener for every `<button>` in the header and this prevents the `onclick` attribute to work.

With this change, the `astraToggleDarkMode()` function is called again in an EventListener, to make the toggle working in a header sidebar as well.