### PR TITLE
Add dark mode logo Customizer option

### DIFF
--- a/lib/Customizer/Configurations/SiteIcon.php
+++ b/lib/Customizer/Configurations/SiteIcon.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Class to register client-side assets (scripts and stylesheets) for the Gutenberg block.
+ *
+ * @package DMFA\Helpers
+ */
+
+namespace DMFA\Customizer\Configurations;
+
+use Astra_Builder_Helper;
+
+/**
+ * Class SiteIcon
+ */
+class SiteIcon {
+	/**
+	 * Registers all block assets so that they can be enqueued through Gutenberg in the corresponding context.
+	 *
+	 * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
+	 */
+	public function init() {
+		add_filter( 'astra_customizer_configurations', [ $this, 'configuration' ] );
+		add_filter( 'astra_replace_header_attr', [ $this, 'dark_mode_image_attribute' ] );
+	}
+
+	/**
+	 * Add new Customizer configurations for the dark mode alternative image.
+	 *
+	 * @param array $configurations The Customizer configurations.
+	 *
+	 * @return array
+	 */
+	public function configuration( $configurations ) {
+		$_section = 'title_tagline';
+		$_configs = [
+			[
+				'name'      => ASTRA_THEME_SETTINGS . '[different-dark-mode-logo]',
+				'type'      => 'control',
+				'control'   => 'ast-toggle-control',
+				'section'   => $_section,
+				'title'     => __( 'Different Logo For Dark Mode?', 'dark-mode-for-astra' ),
+				'default'   => astra_get_option( 'different-dark-mode-logo' ),
+				'priority'  => 4,
+				'transport' => 'postMessage',
+				'divider'   => [ 'ast_class' => 'ast-top-dotted-divider' ],
+				'context'   => [
+					[
+						'setting'  => 'custom_logo',
+						'operator' => '!=',
+						'value'    => '',
+					],
+					Astra_Builder_Helper::$general_tab_config,
+				],
+				'partial'   => [
+					'selector'            => '.site-branding',
+					'container_inclusive' => false,
+					'render_callback'     => 'Astra_Builder_Header::site_identity',
+				],
+			],
+
+			/**
+			 * Option: Retina logo selector
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[ast-header-dark-mode-logo]',
+				'default'           => astra_get_option( 'ast-header-dark-mode-logo' ),
+				'type'              => 'control',
+				'control'           => 'image',
+				'sanitize_callback' => 'esc_url_raw',
+				'section'           => 'title_tagline',
+				'context'           => array(
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[different-dark-mode-logo]',
+						'operator' => '!=',
+						'value'    => 0,
+					),
+					Astra_Builder_Helper::$general_tab_config,
+				),
+				'priority'          => 4.5,
+				'title'             => __( 'Darf Mode Logo', 'dark-mode-for-astra' ),
+				'library_filter'    => array( 'gif', 'jpg', 'jpeg', 'png', 'ico' ),
+				'transport'         => 'postMessage',
+				'partial'           => array(
+					'selector'            => '.site-branding',
+					'container_inclusive' => false,
+					'render_callback'     => 'Astra_Builder_Header::site_identity',
+				),
+			),
+		];
+
+		$configurations = array_merge( $configurations, $_configs );
+
+		return $configurations;
+	}
+
+	/**
+	 * Add a data attribute for the dark mode src to the site icon image.
+	 *
+	 * @param array $attr The image tag attributes.
+	 *
+	 * @return array
+	 */
+	public function dark_mode_image_attribute( $attr ) {
+		$diff_dark_mode_logo = astra_get_option( 'different-dark-mode-logo' );
+		if ( $diff_dark_mode_logo ) {
+			$dark_mode_logo = astra_get_option( 'ast-header-dark-mode-logo' );
+			if ( apply_filters( 'dmfa_astra_main_header_dark_mode', true ) && '' !== $dark_mode_logo ) {
+				$attr['data-dark-mode-src'] = $dark_mode_logo;
+				// Generate "srcset" and "sizes" attributes for the dark mode logo.
+				$dark_mode_logo_id = attachment_url_to_postid( $dark_mode_logo );
+				$image_meta        = wp_get_attachment_metadata( $dark_mode_logo_id );
+				$image             = wp_get_attachment_image_src( $dark_mode_logo_id, 'ast-transparent-logo-size', false );
+				if ( $image ) {
+					list( $src, $width, $height ) = $image;
+					if ( is_array( $image_meta ) ) {
+						$size_array = array( absint( $width ), absint( $height ) );
+						$srcset     = wp_calculate_image_srcset( $size_array, $src, $image_meta, $dark_mode_logo_id );
+						$sizes      = wp_calculate_image_sizes( $size_array, $src, $image_meta, $dark_mode_logo_id );
+						if ( $srcset && ( $sizes || ! empty( $attr['sizes'] ) ) ) {
+							$attr['data-dark-mode-srcset'] = $srcset;
+							$attr['data-dark-mode-sizes']  = $sizes;
+						}
+					}
+				}
+			}
+		}
+
+		return $attr;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -7,6 +7,7 @@
 
 namespace DMFA;
 
+use DMFA\Customizer\Configurations\SiteIcon;
 use DMFA\Helpers\AssetsLoader;
 use DMFA\Helpers\DarkMode;
 
@@ -16,8 +17,9 @@ use DMFA\Helpers\DarkMode;
 function init() {
 	// Construct all modules to initialize.
 	$modules = [
-		'helpers_assets_loader' => new AssetsLoader(),
-		'helpers_dark_mode'     => new DarkMode(),
+		'helpers_assets_loader'       => new AssetsLoader(),
+		'helpers_dark_mode'           => new DarkMode(),
+		'customizer_config_site_icon' => new SiteIcon(),
 	];
 
 	// Initialize all modules.

--- a/src/dark-mode-toggler.js
+++ b/src/dark-mode-toggler.js
@@ -1,16 +1,33 @@
 function astraToggleDarkMode() { // jshint ignore:line
-	var toggler = document.getElementById( 'dark-mode-toggler' );
+	var toggler = document.getElementById( 'dark-mode-toggler' ),
+		siteIcon = document.querySelector( '.site-logo-img img' );
 
 	if ( 'false' === toggler.getAttribute( 'aria-pressed' ) ) {
 		toggler.setAttribute( 'aria-pressed', 'true' );
 		document.documentElement.classList.add( 'is-dark-theme' );
 		document.body.classList.add( 'is-dark-theme' );
 		window.localStorage.setItem( 'astraDarkMode', 'yes' );
+		if ( siteIcon.dataset.darkModeSrc ) {
+			siteIcon.dataset.lightModeSrc = siteIcon.src;
+			siteIcon.dataset.lightModeSrcset = siteIcon.srcset;
+			siteIcon.dataset.lightModeSizes = siteIcon.srcset;
+			siteIcon.src = siteIcon.dataset.darkModeSrc;
+			siteIcon.srcset = siteIcon.dataset.darkModeSrcset;
+			siteIcon.sizes = siteIcon.dataset.darkModeSizes;
+		}
 	} else {
 		toggler.setAttribute( 'aria-pressed', 'false' );
 		document.documentElement.classList.remove( 'is-dark-theme' );
 		document.body.classList.remove( 'is-dark-theme' );
 		window.localStorage.setItem( 'astraDarkMode', 'no' );
+		if ( siteIcon.dataset.lightModeSrc ) {
+			siteIcon.dataset.darkModeSrc = siteIcon.src;
+			siteIcon.dataset.darkModeSrcset = siteIcon.srcset;
+			siteIcon.dataset.darkModeSizes = siteIcon.srcset;
+			siteIcon.src = siteIcon.dataset.lightModeSrc;
+			siteIcon.srcset = siteIcon.dataset.lightModeSrcset;
+			siteIcon.sizes = siteIcon.dataset.lightModeSizes;
+		}
 	}
 }
 
@@ -30,16 +47,8 @@ function darkModeInitialLoad() {
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
 		isDarkMode = astraIsDarkMode();
 
-	if ( isDarkMode ) {
-		document.documentElement.classList.add( 'is-dark-theme' );
-		document.body.classList.add( 'is-dark-theme' );
-	} else {
-		document.documentElement.classList.remove( 'is-dark-theme' );
-		document.body.classList.remove( 'is-dark-theme' );
-	}
-
-	if ( toggler && isDarkMode ) {
-		toggler.setAttribute( 'aria-pressed', 'true' );
+	if ( isDarkMode && ! document.documentElement.classList.contains('is-dark-theme') ) {
+		astraToggleDarkMode();
 	}
 
 	if ( 'fixed' === window.getComputedStyle( toggler ).position ) {
@@ -50,7 +59,6 @@ function darkModeInitialLoad() {
 }
 
 function darkModeRepositionTogglerOnScroll() {
-
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
 		prevScroll = window.scrollY || document.documentElement.scrollTop,
 		currentScroll,


### PR DESCRIPTION
This adds a toggle and a logo/media selection to the "site identity" Customizer configuration so a different logo can be used for the dark mode.

Closes #2 