### PR TITLE
Add dark mode color scheme Customizer option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
-        "squizlabs/php_codesniffer": "^3.7",
-        "wp-coding-standards/wpcs": "^2.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "wp-coding-standards/wpcs": "^3",
         "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "license": "GPL-3.0-or-later",

--- a/dark-mode-for-astra.php
+++ b/dark-mode-for-astra.php
@@ -63,7 +63,7 @@ function dmfa_pre_init() {
  * Load plugin textdomain.
  */
 function dmfa_load_textdomain() {
-	load_plugin_textdomain( 'dark-mode-for-astra', false, basename( dirname( __FILE__ ) ) . '/languages' );
+	load_plugin_textdomain( 'dark-mode-for-astra', false, basename( __DIR__ ) . '/languages' );
 }
 
 /**

--- a/lib/Customizer/Configurations/DarkMode.php
+++ b/lib/Customizer/Configurations/DarkMode.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class to register client-side assets (scripts and stylesheets) for the Gutenberg block.
+ *
+ * @package DMFA\Helpers
+ */
+
+namespace DMFA\Customizer\Configurations;
+
+use Astra_Builder_Helper;
+
+/**
+ * Class SiteIcon
+ */
+class DarkMode {
+	/**
+	 * Registers all block assets so that they can be enqueued through Gutenberg in the corresponding context.
+	 *
+	 * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
+	 */
+	public function init() {
+		add_filter( 'astra_customizer_configurations', [ $this, 'configuration' ] );
+	}
+
+	/**
+	 * Add new Customizer configurations for the dark mode alternative image.
+	 *
+	 * @param array $configurations The Customizer configurations.
+	 *
+	 * @return array
+	 */
+	public function configuration( $configurations ) {
+		$color_palettes = [
+			'palette_1' => __( 'Style 1', 'dark-mode-for-astra' ),
+			'palette_2' => __( 'Style 2', 'dark-mode-for-astra' ),
+			'palette_3' => __( 'Style 3', 'dark-mode-for-astra' ),
+		];
+		$_configs       = [
+			[
+				'name'     => 'panel-dark-mode-for-astra',
+				'type'     => 'panel',
+				'priority' => 70,
+				'title'    => __( 'Dark Mode', 'dark-mode-for-astra' ),
+			],
+			[
+				'name'     => 'section-dark-mode-for-astra',
+				'type'     => 'section',
+				'priority' => 5,
+				'title'    => __( 'Color Palettes', 'dark-mode-for-astra' ),
+				'panel'    => 'panel-dark-mode-for-astra',
+			],
+
+			/**
+			 * Color Scheme
+			 */
+			[
+				'name'       => ASTRA_THEME_SETTINGS . '[dmfa-dark-mode-color-scheme]',
+				'default'    => astra_get_option( 'dmfa-dark-mode-color-scheme', 'none' ),
+				'section'    => 'section-dark-mode-for-astra',
+				'title'      => __( 'Dark Mode Colors', 'dark-mode-for-astra' ),
+				'type'       => 'control',
+				'control'    => 'ast-select',
+				'priority'   => 5,
+				'choices'    => $color_palettes,
+				'partial'    => [
+					'selector'            => '.ast-dfma-dark-mode-color-scheme-wrapper .ast-dfma-dark-mode-color-scheme .trail-items',
+					'container_inclusive' => false,
+				],
+				'context'    => Astra_Builder_Helper::$general_tab,
+				'responsive' => false,
+				'renderAs'   => 'text',
+				'divider'    => [ 'ast_class' => 'ast-section-spacing' ],
+			],
+		];
+
+		$configurations = array_merge( $configurations, $_configs );
+
+		return $configurations;
+	}
+}

--- a/lib/Customizer/Configurations/SiteIcon.php
+++ b/lib/Customizer/Configurations/SiteIcon.php
@@ -34,12 +34,12 @@ class SiteIcon {
 		$_section = 'title_tagline';
 		$_configs = [
 			[
-				'name'      => ASTRA_THEME_SETTINGS . '[different-dark-mode-logo]',
+				'name'      => ASTRA_THEME_SETTINGS . '[dmfa-different-dark-mode-logo]',
 				'type'      => 'control',
 				'control'   => 'ast-toggle-control',
 				'section'   => $_section,
 				'title'     => __( 'Different Logo For Dark Mode?', 'dark-mode-for-astra' ),
-				'default'   => astra_get_option( 'different-dark-mode-logo' ),
+				'default'   => astra_get_option( 'dmfa-different-dark-mode-logo' ),
 				'priority'  => 4,
 				'transport' => 'postMessage',
 				'divider'   => [ 'ast_class' => 'ast-top-dotted-divider' ],
@@ -59,18 +59,18 @@ class SiteIcon {
 			],
 
 			/**
-			 * Option: Retina logo selector
+			 * Option: Dark Mode logo selector
 			 */
 			[
-				'name'              => ASTRA_THEME_SETTINGS . '[ast-header-dark-mode-logo]',
-				'default'           => astra_get_option( 'ast-header-dark-mode-logo' ),
+				'name'              => ASTRA_THEME_SETTINGS . '[ast-header-dmfa-dark-mode-logo]',
+				'default'           => astra_get_option( 'ast-header-dmfa-dark-mode-logo' ),
 				'type'              => 'control',
 				'control'           => 'image',
 				'sanitize_callback' => 'esc_url_raw',
 				'section'           => 'title_tagline',
 				'context'           => [
 					[
-						'setting'  => ASTRA_THEME_SETTINGS . '[different-dark-mode-logo]',
+						'setting'  => ASTRA_THEME_SETTINGS . '[dmfa-different-dark-mode-logo]',
 						'operator' => '!=',
 						'value'    => 0,
 					],
@@ -101,9 +101,9 @@ class SiteIcon {
 	 * @return array
 	 */
 	public function dark_mode_image_attribute( $attr ) {
-		$diff_dark_mode_logo = astra_get_option( 'different-dark-mode-logo' );
+		$diff_dark_mode_logo = astra_get_option( 'dmfa-different-dark-mode-logo' );
 		if ( $diff_dark_mode_logo ) {
-			$dark_mode_logo = astra_get_option( 'ast-header-dark-mode-logo' );
+			$dark_mode_logo = astra_get_option( 'ast-header-dmfa-dark-mode-logo' );
 			if ( apply_filters( 'dmfa_astra_main_header_dark_mode', true ) && '' !== $dark_mode_logo ) {
 				$attr['data-dark-mode-src'] = $dark_mode_logo;
 				// Generate "srcset" and "sizes" attributes for the dark mode logo.

--- a/lib/Customizer/Configurations/SiteIcon.php
+++ b/lib/Customizer/Configurations/SiteIcon.php
@@ -61,31 +61,31 @@ class SiteIcon {
 			/**
 			 * Option: Retina logo selector
 			 */
-			array(
+			[
 				'name'              => ASTRA_THEME_SETTINGS . '[ast-header-dark-mode-logo]',
 				'default'           => astra_get_option( 'ast-header-dark-mode-logo' ),
 				'type'              => 'control',
 				'control'           => 'image',
 				'sanitize_callback' => 'esc_url_raw',
 				'section'           => 'title_tagline',
-				'context'           => array(
-					array(
+				'context'           => [
+					[
 						'setting'  => ASTRA_THEME_SETTINGS . '[different-dark-mode-logo]',
 						'operator' => '!=',
 						'value'    => 0,
-					),
+					],
 					Astra_Builder_Helper::$general_tab_config,
-				),
+				],
 				'priority'          => 4.5,
 				'title'             => __( 'Darf Mode Logo', 'dark-mode-for-astra' ),
-				'library_filter'    => array( 'gif', 'jpg', 'jpeg', 'png', 'ico' ),
+				'library_filter'    => [ 'gif', 'jpg', 'jpeg', 'png', 'ico' ],
 				'transport'         => 'postMessage',
-				'partial'           => array(
+				'partial'           => [
 					'selector'            => '.site-branding',
 					'container_inclusive' => false,
 					'render_callback'     => 'Astra_Builder_Header::site_identity',
-				),
-			),
+				],
+			],
 		];
 
 		$configurations = array_merge( $configurations, $_configs );

--- a/lib/Customizer/Configurations/SiteIcon.php
+++ b/lib/Customizer/Configurations/SiteIcon.php
@@ -116,7 +116,7 @@ class SiteIcon {
 						$size_array = array( absint( $width ), absint( $height ) );
 						$srcset     = wp_calculate_image_srcset( $size_array, $src, $image_meta, $dark_mode_logo_id );
 						$sizes      = wp_calculate_image_sizes( $size_array, $src, $image_meta, $dark_mode_logo_id );
-						if ( $srcset && ( $sizes || ! empty( $attr['sizes'] ) ) ) {
+						if ( $srcset && $sizes ) {
 							$attr['data-dark-mode-srcset'] = $srcset;
 							$attr['data-dark-mode-sizes']  = $sizes;
 						}

--- a/lib/Helpers/DarkMode.php
+++ b/lib/Helpers/DarkMode.php
@@ -141,16 +141,10 @@ class DarkMode {
 	 * Print the CSS for the Astra color palette to be used for the dark mode.
 	 */
 	public function astra_color_palettes() {
-		$color_palettes = get_option( 'astra-color-palettes' );
-		$astra_settings = get_option( 'astra-settings' );
-
-		/**
-		 * Filters for the color palette to be used for the dark mode.
-		 *
-		 * @param string $color_palette The option's index key of the color palette to be used. Default: 'palette_2'.
-		 */
-		$light_mode_color_palette = apply_filters( 'dmfa_color_palett', 'palette_1' );
-		$dark_mode_color_palette  = apply_filters( 'dmfa_color_palett', 'palette_2' );
+		$color_palettes           = get_option( 'astra-color-palettes' );
+		$astra_settings           = get_option( 'astra-settings' );
+		$light_mode_color_palette = $color_palettes['currentPalette'];
+		$dark_mode_color_palette  = astra_get_option( 'dmfa-dark-mode-color-scheme', 'palette_2' );
 
 		$light_color_text              = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],

--- a/lib/Helpers/DarkMode.php
+++ b/lib/Helpers/DarkMode.php
@@ -17,9 +17,10 @@ class DarkMode {
 	 */
 	public function init() {
 		// Add the switch on the frontend.
-		add_shortcode( 'dark-mode-for-astra-toggle', [ $this, 'the_html' ] );
+		add_action( 'admin_init', [ $this, 'add_privacy_policy_content' ] );
 		add_action( 'wp_footer', [ $this, 'maybe_inject_fixed_button' ] );
 		add_action( 'wp_footer', [ $this, 'astra_color_palettes' ] );
+		add_shortcode( 'dark-mode-for-astra-toggle', [ $this, 'the_html' ] );
 	}
 
 	/**
@@ -55,26 +56,32 @@ class DarkMode {
 		?>
 		<style>
 			#dark-mode-toggler > span {
-				margin-<?php echo is_rtl() ? 'right' : 'left'; ?>: 5px;
+				margin- <?php echo is_rtl() ? 'right' : 'left'; ?>: 5px;
 			}
+
 			#dark-mode-toggler > span::before {
 				content: '<?php esc_attr_e( 'Off', 'dark-mode-for-astra' ); ?>';
 			}
+
 			#dark-mode-toggler[aria-pressed="true"] > span::before {
 				content: '<?php esc_attr_e( 'On', 'dark-mode-for-astra' ); ?>';
 			}
+
 			<?php if ( is_admin() || wp_is_json_request() ) : ?>
-				.components-editor-notices__pinned ~ .edit-post-visual-editor #dark-mode-toggler {
-					z-index: 20;
+			.components-editor-notices__pinned ~ .edit-post-visual-editor #dark-mode-toggler {
+				z-index: 20;
+			}
+
+			.is-dark-theme.is-dark-theme #dark-mode-toggler:not(:hover):not(:focus) {
+				color: var(--global--color-primary);
+			}
+
+			@media only screen and (max-width: 782px) {
+				#dark-mode-toggler {
+					margin-top: 32px;
 				}
-				.is-dark-theme.is-dark-theme #dark-mode-toggler:not(:hover):not(:focus) {
-					color: var(--global--color-primary);
-				}
-				@media only screen and (max-width: 782px) {
-					#dark-mode-toggler {
-						margin-top: 32px;
-					}
-				}
+			}
+
 			<?php endif; ?>
 		</style>
 
@@ -138,26 +145,26 @@ class DarkMode {
 		$astra_settings = get_option( 'astra-settings' );
 
 		/**
-		 * Filters for the color palett to be used for the dark mode.
+		 * Filters for the color palette to be used for the dark mode.
 		 *
 		 * @param string $color_palette The option's index key of the color palette to be used. Default: 'palette_2'.
 		 */
 		$light_mode_color_palette = apply_filters( 'dmfa_color_palett', 'palette_1' );
 		$dark_mode_color_palette  = apply_filters( 'dmfa_color_palett', 'palette_2' );
 
-		$light_color_text = $this->get_color_from_settings(
+		$light_color_text              = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['button-color']
 		);
-		$light_color_background = $this->get_color_from_settings(
+		$light_color_background        = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['button-bg-color']
 		);
-		$light_color_border = $this->get_color_from_settings(
+		$light_color_border            = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['theme-button-border-group-border-color']
 		);
-		$light_color_text_active = $this->get_color_from_settings(
+		$light_color_text_active       = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['button-h-color']
 		);
@@ -165,24 +172,24 @@ class DarkMode {
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['button-bg-h-color']
 		);
-		$light_color_border_active = $this->get_color_from_settings(
+		$light_color_border_active     = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $light_mode_color_palette ],
 			$astra_settings['theme-button-border-group-border-h-color']
 		);
 
-		$dark_color_text = $this->get_color_from_settings(
+		$dark_color_text              = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['button-color']
 		);
-		$dark_color_background = $this->get_color_from_settings(
+		$dark_color_background        = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['button-bg-color']
 		);
-		$dark_color_border = $this->get_color_from_settings(
+		$dark_color_border            = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['theme-button-border-group-border-color']
 		);
-		$dark_color_text_active = $this->get_color_from_settings(
+		$dark_color_text_active       = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['button-h-color']
 		);
@@ -190,46 +197,55 @@ class DarkMode {
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['button-bg-h-color']
 		);
-		$dark_color_border_active = $this->get_color_from_settings(
+		$dark_color_border_active     = $this->get_color_from_settings(
 			$color_palettes['palettes'][ $dark_mode_color_palette ],
 			$astra_settings['theme-button-border-group-border-h-color']
 		);
 		?>
 		<style>
 			html:not(.is-dark-theme) {
-				--ast-dark-mode--button-text-color: <?php echo esc_attr( $light_color_text); ?>;
-				--ast-dark-mode--button-border-color: <?php echo esc_attr( $light_color_background); ?>;
-				--ast-dark-mode--button-background-color: <?php echo esc_attr( $light_color_border); ?>;
-				--ast-dark-mode--button-text-color-active: <?php echo esc_attr( $light_color_text_active); ?>;
-				--ast-dark-mode--button-border-color-active: <?php echo esc_attr( $light_color_background_active); ?>;
-				--ast-dark-mode--button-background-color-active: <?php echo esc_attr( $light_color_border_active); ?>;
+				--ast-dark-mode--button-text-color: <?php echo esc_attr( $light_color_text ); ?>;
+				--ast-dark-mode--button-border-color: <?php echo esc_attr( $light_color_background ); ?>;
+				--ast-dark-mode--button-background-color: <?php echo esc_attr( $light_color_border ); ?>;
+				--ast-dark-mode--button-text-color-active: <?php echo esc_attr( $light_color_text_active ); ?>;
+				--ast-dark-mode--button-border-color-active: <?php echo esc_attr( $light_color_background_active ); ?>;
+				--ast-dark-mode--button-background-color-active: <?php echo esc_attr( $light_color_border_active ); ?>;
 			}
+
 			html.is-dark-theme {
-				<?php
-				foreach ( $color_palettes['palettes'][ $dark_mode_color_palette ] as $key => $value ) {
-					printf(
-						'--ast-global-color-%d: %s;',
-						(int) $key,
-						esc_attr( $value )
-					);
-				}
-				?>
-				--ast-dark-mode--button-text-color: <?php echo esc_attr( $dark_color_text); ?>;
-				--ast-dark-mode--button-border-color: <?php echo esc_attr( $dark_color_background); ?>;
-				--ast-dark-mode--button-background-color: <?php echo esc_attr( $dark_color_border); ?>;
-				--ast-dark-mode--button-text-color-active: <?php echo esc_attr( $dark_color_text_active); ?>;
-				--ast-dark-mode--button-border-color-active: <?php echo esc_attr( $dark_color_background_active); ?>;
-				--ast-dark-mode--button-background-color-active: <?php echo esc_attr( $dark_color_border_active); ?>;
+			<?php
+			foreach ( $color_palettes['palettes'][ $dark_mode_color_palette ] as $key => $value ) {
+				printf(
+					'--ast-global-color-%d: %s;',
+					(int) $key,
+					esc_attr( $value )
+				);
+			}
+			?>
+			--ast-dark-mode--button-text-color: <?php echo esc_attr( $dark_color_text ); ?>;
+				--ast-dark-mode--button-border-color: <?php echo esc_attr( $dark_color_background ); ?>;
+				--ast-dark-mode--button-background-color: <?php echo esc_attr( $dark_color_border ); ?>;
+				--ast-dark-mode--button-text-color-active: <?php echo esc_attr( $dark_color_text_active ); ?>;
+				--ast-dark-mode--button-border-color-active: <?php echo esc_attr( $dark_color_background_active ); ?>;
+				--ast-dark-mode--button-background-color-active: <?php echo esc_attr( $dark_color_border_active ); ?>;
 			}
 		</style>
 		<?php
 	}
 
+	/**
+	 * Find a setting's value in the color palette.
+	 *
+	 * @param array  $color_palette The color palette array.
+	 * @param string $setting The setting to find in the color palette.
+	 *
+	 * @return mixed
+	 */
 	public function get_color_from_settings( $color_palette, $setting ) {
 		// Check, if the color is using a global variable.
 		preg_match( '/var\(--ast-global-color-(\d+)\)/', $setting, $matches );
 		if ( isset( $matches[1] ) ) {
-			return $color_palette[$matches[1]];
+			return $color_palette[ $matches[1] ];
 		} else {
 			return $setting;
 		}
@@ -244,9 +260,15 @@ class DarkMode {
 		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
 			return;
 		}
-		$content = '<p class="privacy-policy-tutorial">' . __( 'Dark Mode for Astra uses LocalStorage when Dark Mode support is enabled.', 'dark-mode-for-astra' ) . '</p>'
-				   . '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'dark-mode-for-astra' ) . '</strong> '
-				   . __( 'This website uses LocalStorage to save the setting when Dark Mode support is turned on or off.<br> LocalStorage is necessary for the setting to work and is only used when a user clicks on the Dark Mode button.<br> No data is saved in the database or transferred.', 'dark-mode-for-astra' );
+		$content = sprintf(
+			'<p class="privacy-policy-tutorial">%1$s</p><strong class="privacy-policy-tutorial">%2$s</strong> %3$s',
+			__( 'Dark Mode for Astra uses LocalStorage when Dark Mode support is enabled.', 'dark-mode-for-astra' ),
+			__( 'Suggested text:', 'dark-mode-for-astra' ),
+			__(
+				'This website uses LocalStorage to save the setting when Dark Mode support is turned on or off.<br> LocalStorage is necessary for the setting to work and is only used when a user clicks on the Dark Mode button.<br> No data is saved in the database or transferred.',
+				'dark-mode-for-astra'
+			)
+		);
 		wp_add_privacy_policy_content( __( 'Dark Mode for Astra', 'dark-mode-for-astra' ), wp_kses_post( wpautop( $content, false ) ) );
 	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -7,6 +7,7 @@
 
 namespace DMFA;
 
+use DMFA\Customizer\Configurations\DarkMode as DarkModeConfig;
 use DMFA\Customizer\Configurations\SiteIcon;
 use DMFA\Helpers\AssetsLoader;
 use DMFA\Helpers\DarkMode;
@@ -17,9 +18,10 @@ use DMFA\Helpers\DarkMode;
 function init() {
 	// Construct all modules to initialize.
 	$modules = [
+		'customizer_config_dark_mode' => new DarkModeConfig(),
+		'customizer_config_site_icon' => new SiteIcon(),
 		'helpers_assets_loader'       => new AssetsLoader(),
 		'helpers_dark_mode'           => new DarkMode(),
-		'customizer_config_site_icon' => new SiteIcon(),
 	];
 
 	// Initialize all modules.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -51,7 +51,7 @@
 
 	<rule ref="WordPress">
 		<!-- As we use PHP 5.4+ now, we can use the short array syntax -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 		<!-- Uncomment if you develop a theme with templates for CPTs having a prefix -->
 		<exclude name="WordPress.Files.FileName" />
 		<!-- Uncomment for projects using the metabox toolbox -->

--- a/src/dark-mode-toggler.js
+++ b/src/dark-mode-toggler.js
@@ -9,11 +9,20 @@ function astraToggleDarkMode() { // jshint ignore:line
 		window.localStorage.setItem( 'astraDarkMode', 'yes' );
 		if ( siteIcon.dataset.darkModeSrc ) {
 			siteIcon.dataset.lightModeSrc = siteIcon.src;
-			siteIcon.dataset.lightModeSrcset = siteIcon.srcset;
-			siteIcon.dataset.lightModeSizes = siteIcon.srcset;
+			if(siteIcon.srcset) {
+				siteIcon.dataset.lightModeSrcset = siteIcon.srcset;
+			}
+			if(siteIcon.sizes) {
+				siteIcon.dataset.lightModeSizes = siteIcon.sizes;
+			}
+
 			siteIcon.src = siteIcon.dataset.darkModeSrc;
-			siteIcon.srcset = siteIcon.dataset.darkModeSrcset;
-			siteIcon.sizes = siteIcon.dataset.darkModeSizes;
+			if ( siteIcon.dataset.darkModeSrcset ) {
+				siteIcon.srcset = siteIcon.dataset.darkModeSrcset;
+			}
+			if ( siteIcon.dataset.darkModeSizes ) {
+				siteIcon.sizes = siteIcon.dataset.darkModeSizes;
+			}
 		}
 	} else {
 		toggler.setAttribute( 'aria-pressed', 'false' );
@@ -22,11 +31,20 @@ function astraToggleDarkMode() { // jshint ignore:line
 		window.localStorage.setItem( 'astraDarkMode', 'no' );
 		if ( siteIcon.dataset.lightModeSrc ) {
 			siteIcon.dataset.darkModeSrc = siteIcon.src;
-			siteIcon.dataset.darkModeSrcset = siteIcon.srcset;
-			siteIcon.dataset.darkModeSizes = siteIcon.srcset;
+			if(siteIcon.srcset) {
+				siteIcon.dataset.darkModeSrcset = siteIcon.srcset;
+			}
+			if(siteIcon.sizes) {
+				siteIcon.dataset.darkModeSizes = siteIcon.sizes;
+			}
+
 			siteIcon.src = siteIcon.dataset.lightModeSrc;
-			siteIcon.srcset = siteIcon.dataset.lightModeSrcset;
-			siteIcon.sizes = siteIcon.dataset.lightModeSizes;
+			if ( siteIcon.dataset.lightModeSrcset ) {
+				siteIcon.srcset = siteIcon.dataset.lightModeSrcset;
+			}
+			if ( siteIcon.dataset.lightModeSizes ) {
+				siteIcon.sizes = siteIcon.dataset.lightModeSizes;
+			}
 		}
 	}
 }
@@ -47,7 +65,7 @@ function darkModeInitialLoad() {
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
 		isDarkMode = astraIsDarkMode();
 
-	if ( isDarkMode && ! document.documentElement.classList.contains('is-dark-theme') ) {
+	if ( isDarkMode && !document.documentElement.classList.contains( 'is-dark-theme' ) ) {
 		astraToggleDarkMode();
 	}
 


### PR DESCRIPTION
This adds a selection for the current color scheme ("Style #") to a separate Customizer panel for the Dark Mode plugin. The light mode is always the current color scheme selected "Customizing -> Colors -> Global Palette".

Closes #1 